### PR TITLE
Use the BuildConfig's package name for the Authority

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rain.util.android</groupId>
     <artifactId>RoboCoP</artifactId>
-    <version>0.5.11</version>
+    <version>0.5.12</version>
     <packaging>jar</packaging>
 
     <dependencies>

--- a/src/main/resources/ContentProvider.vm
+++ b/src/main/resources/ContentProvider.vm
@@ -1,7 +1,7 @@
 package ${packageName}.provider;
 
+import ${packageName}.BuildConfig;
 import ${packageName}.database.${providerName}Database;
-
 import ${packageName}.database.table.*;
 
 import android.provider.BaseColumns;
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class ${providerName}Provider extends ContentProvider {
 
-    public static final String AUTHORITY = "${packageName}.provider";
+    public static final String AUTHORITY = BuildConfig.PACKAGE_NAME + ".provider";
 
     public static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
 

--- a/src/main/resources/ProviderXML.vm
+++ b/src/main/resources/ProviderXML.vm
@@ -1,1 +1,4 @@
-<provider android:name="${packageName}.provider.${providerName}Provider" android:authorities="${packageName}.provider" android:exported="false" />
+<provider
+    android:name="${packageName}.provider.${providerName}Provider"
+    android:authorities="${applicationId}.data.provider"
+    android:exported="false" />


### PR DESCRIPTION
Doing so allows for the provider name to be dynamically set
in AndroidManifest.xml via the ${applicationId} variable.
This avoids duplicate provider names in the case where different
product flavors try to get installed.
