### PR TITLE
Add support to generate classes only

### DIFF
--- a/ClientTest/resources/classes_only_schema.json
+++ b/ClientTest/resources/classes_only_schema.json
@@ -1,0 +1,116 @@
+{
+  "application_id": "com.brightcove.nh4apidemo",
+  "packageName": "com.brightcove.nh4apidemo.data",
+  "classes": [
+    {
+      "name": "Nh4Screen",
+      "serialize_all_names": "true",
+      "members": [
+        {
+          "type": "array",
+          "array_type": "Nh4Item",
+          "name": "items"
+        },
+        {
+          "type": "int",
+          "name": "screen_template_id"
+        },
+        {
+          "type": "string",
+          "name": "header_title"
+        },
+        {
+          "type": "string",
+          "name": "edit_post_api"
+        }
+      ]
+    },
+    {
+      "name": "Nh4Item",
+      "serialize_all_names": "true",
+      "members": [
+        {
+          "type": "array",
+          "array_type": "VcPlaylist",
+          "name": "items"
+        },
+        {
+          "type": "int",
+          "name": "type"
+        },
+        {
+          "type": "string",
+          "name": "id"
+        },
+        {
+          "type": "string",
+          "name": "title"
+        },
+        {
+          "type": "array",
+          "array_type": "Nh4SortOption",
+          "name": "sort_options"
+        },
+        {
+          "type": "array",
+          "array_type": "Nh4Item",
+          "name": "items"
+        },
+        {
+          "type": "string",
+          "name": "items_api"
+        },
+        {
+          "type": "string",
+          "name": "image"
+        },
+        {
+          "type": "string",
+          "name": "subtitle"
+        },
+        {
+          "type": "string",
+          "name": "lead_text"
+        },
+        {
+          "type": "string",
+          "name": "description"
+        },
+        {
+          "type": "string",
+          "name": "badge_overlay"
+        },
+        {
+          "type": "boolean",
+          "name": "lockable"
+        },
+        {
+          "type": "string",
+          "name": "screen_api"
+        },
+        {
+          "type": "string",
+          "name": "anchor"
+        },
+        {
+          "type": "string",
+          "name": "queue_api"
+        }
+      ]
+    },
+    {
+      "name": "Nh4SortOption",
+      "serialize_all_names": "true",
+      "members": [
+        {
+          "type": "string",
+          "name": "title"
+        },
+        {
+          "type": "string",
+          "name": "api"
+        }
+      ]
+    }
+  ]
+}

--- a/ClientTest/src/com/rain/utils/android/robocop/clienttest/Main.java
+++ b/ClientTest/src/com/rain/utils/android/robocop/clienttest/Main.java
@@ -11,6 +11,6 @@ import com.rain.utils.android.robocop.generator.ContentProviderWriter;
 public class Main {
     public static void main(String[] args) {
         ContentProviderWriter writer = new ContentProviderWriter();
-        writer.createContentProvider("ClientTest/resources/example_schema.json", "ClientTest/src-gen/");
+        writer.createContentProvider("ClientTest/resources/classes_only_schema.json", "ClientTest/src-gen/");
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'maven-publish'
 apply plugin: "com.jfrog.artifactory"
 
 group = 'com.rain.util.android'
-version = '0.5.17'
+version = '0.5.18'
 
 repositories {        
      maven { url "http://repo.maven.apache.org/maven2" }

--- a/src/main/java/com/rain/utils/android/robocop/generator/ContentProviderWriter.java
+++ b/src/main/java/com/rain/utils/android/robocop/generator/ContentProviderWriter.java
@@ -69,51 +69,56 @@ public class ContentProviderWriter {
             baseContext.put("applicationId", contentProviderModel.getApplicationId());
             baseContext.put("providerModel", contentProviderModel);
 
-            // Create Content Provider class and AndroidManifest XML definition
-            VelocityContext providerContext = new VelocityContext(baseContext);
-            providerContext.put("providerName", contentProviderModel.getProviderName());
-            providerContext.put("tables", contentProviderModel.getTables());
-            providerContext.put("relationships", contentProviderModel.getRelationships());
-            writeFile(engine, providerContext, "ContentProvider.vm", providerPath, "/" + contentProviderModel.getProviderName() + "Provider.java");
-            writeFile(engine, providerContext, "ProviderXML.vm", providerXMLPath, "/content-provider.xml");
+            // Create Content Provider class, AndroidManifest XML definition, and DB class (as long as there are tables defined)
+            if (contentProviderModel.getTables() != null && !contentProviderModel.getTables().isEmpty()) {
+                VelocityContext providerContext = new VelocityContext(baseContext);
+                providerContext.put("providerName", contentProviderModel.getProviderName());
+                providerContext.put("tables", contentProviderModel.getTables());
+                providerContext.put("relationships", contentProviderModel.getRelationships());
+                writeFile(engine, providerContext, "ContentProvider.vm", providerPath, "/" + contentProviderModel.getProviderName() + "Provider.java");
+                writeFile(engine, providerContext, "ProviderXML.vm", providerXMLPath, "/content-provider.xml");
 
-            // Create database class
-            VelocityContext databaseContext = new VelocityContext(providerContext);
-            databaseContext.put("databaseVersion", contentProviderModel.getDatabaseVersion());
-            databaseContext.put("useSqliteAssetHelper", contentProviderModel.getUseSqliteAssetHelper());
-            writeFile(engine, databaseContext, "Database.vm", databasePath, "/" + contentProviderModel.getProviderName() + "Database.java");
+                VelocityContext databaseContext = new VelocityContext(providerContext);
+                databaseContext.put("databaseVersion", contentProviderModel.getDatabaseVersion());
+                databaseContext.put("useSqliteAssetHelper", contentProviderModel.getUseSqliteAssetHelper());
+                writeFile(engine, databaseContext, "Database.vm", databasePath, "/" + contentProviderModel.getProviderName() + "Database.java");
+            }
 
             // Create all simple class models
-            for(ContentProviderTableModel classModel : contentProviderModel.getClasses()) {
-                VelocityContext classContext = new VelocityContext(baseContext);
-                classContext.put("class", classModel);
-                classContext.put("isClass", Boolean.toString(true));
-                classContext.put("className", classModel.getName());
-                classContext.put("fields", classModel.getFields());
-                classContext.put("hasDateType", classModel.getHasDateType());
-                classContext.put("hasArrayType", classModel.getHasArrayType());
-                classContext.put("hasSerializedNames", classModel.getHasSerializedNames());
-                classContext.put("serializeAllNames", classModel.getSerializeAllNames());
-                writeFile(engine, classContext, "Model.vm", modelPath, "/" + classModel.getName() + ".java");
+            if (contentProviderModel.getClasses() != null && !contentProviderModel.getClasses().isEmpty()) {
+                for (ContentProviderTableModel classModel : contentProviderModel.getClasses()) {
+                    VelocityContext classContext = new VelocityContext(baseContext);
+                    classContext.put("class", classModel);
+                    classContext.put("isClass", Boolean.toString(true));
+                    classContext.put("className", classModel.getName());
+                    classContext.put("fields", classModel.getFields());
+                    classContext.put("hasDateType", classModel.getHasDateType());
+                    classContext.put("hasArrayType", classModel.getHasArrayType());
+                    classContext.put("hasSerializedNames", classModel.getHasSerializedNames());
+                    classContext.put("serializeAllNames", classModel.getSerializeAllNames());
+                    writeFile(engine, classContext, "Model.vm", modelPath, "/" + classModel.getName() + ".java");
+                }
             }
 
             // Create all tables and associated model objects
-            for (ContentProviderTableModel table : contentProviderModel.getTables()) {
-                VelocityContext tableContext = new VelocityContext(baseContext);
-                tableContext.put("table", table);
-                tableContext.put("isTable", Boolean.toString(true));
-                tableContext.put("participatingRelationships", contentProviderModel.getRelationshipsForTable(table));
-                tableContext.put("className", table.getTableClassName());
-                tableContext.put("fields", table.getFields());
-                tableContext.put("hasDateType", table.getHasDateType());
-                tableContext.put("hasSerializedNames", table.getHasSerializedNames());
-                tableContext.put("serializeAllNames", table.getSerializeAllNames());
-                tableContext.put("constrainUniqueCols", table.getConstrainUniqueColumns());
-                tableContext.put("createFullTextIndex", table.getCreateFullTextIndex());
-                tableContext.put("fullTextModule", table.getFullTextModule());
-                tableContext.put("hasArrayType", table.getHasArrayType());
-                writeFile(engine, tableContext, "Table.vm", tablePath, "/" + table.getTableClassName() + "Table.java");
-                writeFile(engine, tableContext, "Model.vm", modelPath, "/" + table.getTableClassName() + ".java");
+            if (contentProviderModel.getTables() != null && !contentProviderModel.getTables().isEmpty()) {
+                for (ContentProviderTableModel table : contentProviderModel.getTables()) {
+                    VelocityContext tableContext = new VelocityContext(baseContext);
+                    tableContext.put("table", table);
+                    tableContext.put("isTable", Boolean.toString(true));
+                    tableContext.put("participatingRelationships", contentProviderModel.getRelationshipsForTable(table));
+                    tableContext.put("className", table.getTableClassName());
+                    tableContext.put("fields", table.getFields());
+                    tableContext.put("hasDateType", table.getHasDateType());
+                    tableContext.put("hasSerializedNames", table.getHasSerializedNames());
+                    tableContext.put("serializeAllNames", table.getSerializeAllNames());
+                    tableContext.put("constrainUniqueCols", table.getConstrainUniqueColumns());
+                    tableContext.put("createFullTextIndex", table.getCreateFullTextIndex());
+                    tableContext.put("fullTextModule", table.getFullTextModule());
+                    tableContext.put("hasArrayType", table.getHasArrayType());
+                    writeFile(engine, tableContext, "Table.vm", tablePath, "/" + table.getTableClassName() + "Table.java");
+                    writeFile(engine, tableContext, "Model.vm", modelPath, "/" + table.getTableClassName() + ".java");
+                }
             }
 
         } catch (IOException e) {


### PR DESCRIPTION
This commit adds support for RoboCoP to generate classes only. If only classes are declared in the schema, a ContentProvider and DB class are not created.

Previously, running RoboCoP with a schema that only defined classes would cause RoboCoP to crash.