### PR TITLE
Properly parcel classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'maven-publish'
 apply plugin: "com.jfrog.artifactory"
 
 group = 'com.rain.util.android'
-version = '0.5.18'
+version = '0.5.19'
 
 repositories {        
      maven { url "http://repo.maven.apache.org/maven2" }

--- a/src/main/java/com/rain/utils/android/robocop/model/ContentProviderTableModel.java
+++ b/src/main/java/com/rain/utils/android/robocop/model/ContentProviderTableModel.java
@@ -289,9 +289,8 @@ public class ContentProviderTableModel {
                 case DATE:
                     return "this." + getPrivateVariableName() + " = parcel.readString()";
                 default:
-                    // This is most likely a generated class
-                    // TODO - Figure out how to handle custom classes
-                    return null;
+                    // This is a generated class
+                    return "this." + getPrivateVariableName() + " = parcel.readParcelable(" + mFieldType + ".class.getClassLoader())";
             }
         }
 
@@ -311,9 +310,8 @@ public class ContentProviderTableModel {
                 case DATE:
                     return "dest.writeString(" + getPrivateVariableName() + ")";
                 default:
-                    // This is most likely a generated class
-                    // TODO - Figure out how to handle custom classes
-                    return null;
+                    // This is a generated class
+                    return "dest.writeParcelable(" + getPrivateVariableName() + ", PARCELABLE_WRITE_RETURN_VALUE)";
             }
         }
     }

--- a/src/main/resources/Model.vm
+++ b/src/main/resources/Model.vm
@@ -36,7 +36,9 @@ import java.lang.reflect.Type;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 #end
+#if($isTable)
 import java.util.ArrayList;
+#end
 #if($hasDateType)
 import java.util.Date;
 #end
@@ -347,9 +349,15 @@ public class ${className} implements Parcelable {
 #foreach( $field in $fields )
 #if($field)
 #if(${field.getIsArrayType()})
-        Log.v(tagName, "${className}.${field.getPrivateVariableName()} items:");
-        for (int i = 0; i < ${field.getPrivateVariableName()}.size(); i++) {
-            Log.v(tagName, "  ${field.getPrivateVariableName()}[" + i + "]: " + ${field.getPrivateVariableName()}.get(i));
+        if (${field.getPrivateVariableName()} == null) {
+            Log.v(tagName, "${field.getPrivateVariableName()} is null");
+        } else if (${field.getPrivateVariableName()}.isEmpty()) {
+            Log.v(tagName, "${field.getPrivateVariableName()} is empty");
+        } else {
+            Log.v(tagName, "${className}.${field.getPrivateVariableName()} items:");
+            for (int i = 0; i < ${field.getPrivateVariableName()}.size(); i++) {
+                Log.v(tagName, "  ${field.getPrivateVariableName()}[" + i + "]: " + ${field.getPrivateVariableName()}.get(i));
+            }
         }
 #else
         Log.v(tagName, "${className}.${field.getPrivateVariableName()}: " + ${field.getPrivateVariableName()});


### PR DESCRIPTION
This PR fixes an issue where some class member objects weren't being parceled properly.  If a class has a member object which is in turn another generated class, the member object wasn't being parceled at all.  What this means is that we were losing data when passing an instance of a generated class via an Intent.

This also fixes a crash in the dump method where it wasn't verifying an object existed before attempting to iterate through its contents.