### PR TITLE
Add static fields for serialized names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'maven-publish'
 apply plugin: "com.jfrog.artifactory"
 
 group = 'com.rain.util.android'
-version = '0.5.21'
+version = '0.5.22'
 
 repositories {        
      maven { url "http://repo.maven.apache.org/maven2" }

--- a/src/main/resources/Model.vm
+++ b/src/main/resources/Model.vm
@@ -63,10 +63,12 @@ public class ${className} implements Parcelable {
 #if($field)
 #if(${field.getSerializedName()})
 
+    public static final String SERIALIZED_NAME_$field.getConstantString() = "$field.getSerializedName()";
     @SerializedName("$field.getSerializedName()")
 #elseif($serializeAllNames)
 
 #if(!${field.getIsThrowableType()})
+    public static final String SERIALIZED_NAME_$field.getConstantString() = "$field.getFieldName()";
     @SerializedName("$field.getFieldName()")
 #end
 #end


### PR DESCRIPTION
This PR adds a new static constant to generated classes. The constant's value is the serialized name of each field that defines a class. This constant will be used for custom Gson parsing (as you'll see in a future PR).